### PR TITLE
Add input eos symbol

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -24,6 +24,7 @@ parser.add_argument('--test_data', help='Path to test data')
 parser.add_argument('--cuda_device', default=0, type=int, help='set cuda device to use')
 parser.add_argument('--max_len', type=int, help='Maximum sequence length', default=50)
 parser.add_argument('--batch_size', type=int, help='Batch size', default=32)
+parser.add_argument('--use_input_eos', action='store_true', help='EOS symbol in input sequences is not used by default. Use this flag to enable.')
 
 opt = parser.parse_args()
 
@@ -42,7 +43,7 @@ output_vocab = checkpoint.output_vocab
 
 ############################################################################
 # Prepare dataset and loss
-src = SourceField()
+src = SourceField(opt.use_input_eos)
 tgt = TargetField()
 src.vocab = input_vocab
 tgt.vocab = output_vocab

--- a/lookup_test.sh
+++ b/lookup_test.sh
@@ -29,4 +29,3 @@ echo "\n\nTest training with attention loss and ponderer"
 #python train_model.py --train $TRAIN_PATH --dev $DEV_PATH --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'post-rnn' --attention_method 'mlp' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0 --use_attention_loss --pondering  --batch_size=1 --scale_attention_loss 1 --optim adam
 
 python train_model.py --train $TRAIN_PATH --dev $DEV_PATH --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'post-rnn' --attention_method 'mlp' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0 --use_attention_loss  --batch_size=1 --scale_attention_loss 1 --optim adam
-

--- a/seq2seq/trainer/attention_guidance.py
+++ b/seq2seq/trainer/attention_guidance.py
@@ -22,9 +22,10 @@ class AttentionGenerator(object):
         pad_value (int): target token to use for padding
     """
 
-    def __init__(self, name, key, pad_value=-1):
+    def __init__(self, name, key, input_eos_used, pad_value=-1):
         self.name = name
         self.key = key
+        self.input_eos_used = input_eos_used
         self.pad_value = pad_value
 
     def add_attention_targets(self, input_variables, input_lengths, target_variables):
@@ -58,15 +59,30 @@ class LookupTableAttention(AttentionGenerator):
     _NAME = "lookup_table"
     _KEY = "attention_target"
 
-    def __init__(self, pad_value):
-        super(LookupTableAttention, self).__init__(name=self._NAME, key=self._KEY, pad_value=pad_value)
+    def __init__(self, input_eos_used, pad_value):
+        super(LookupTableAttention, self).__init__(name=self._NAME, key=self._KEY, input_eos_used=input_eos_used, pad_value=pad_value)
 
     def add_attention_targets(self, input_variables, input_lengths, target_variables):
         max_val = max(input_lengths) + 1
         batch_size = input_lengths.size(0)
 
         # get target attentions
-        target_attentions = Variable(torch.cat(tuple([torch.cat((torch.ones(1), torch.arange(l), self.pad_value*torch.ones(max_val-l)), 0) for l in input_lengths]), 0).view(batch_size, max_val+1).long())
+        # The first value is -11, but is anyways always ignored. All values of -1 are also ignored.
+        # If the EOS is used in input we attend the target EOS to the input EOS.
+        if self.input_eos_used:
+            # Example:
+            # INPUT:      01 t1 t2 EOS
+            # OUTPUT: SOS 01 11 00 EOS
+            # ATTN:    -1  0  1  2   3
+            extra_input_eos = 1
+        else:
+            # Example:
+            # INPUT:      01 t1 t2
+            # OUTPUT: SOS 01 11 00 EOS
+            # ATTN:    -1  0  1  2  -1
+            extra_input_eos = 0
+        
+        target_attentions = Variable(torch.cat(tuple([torch.cat((self.pad_value*torch.ones(1), torch.arange(l), self.pad_value*torch.ones(max_val-l-extra_input_eos)), 0) for l in input_lengths]), 0).view(batch_size, max_val+1-extra_input_eos).long())
 
         if torch.cuda.is_available():
             target_attentions = target_attentions.cuda()
@@ -98,9 +114,10 @@ class PonderGenerator(object):
 
     """
 
-    def __init__(self, name, key, pad_token=-1):
+    def __init__(self, name, key, input_eos_used, pad_token=-1):
         self.name = name
         self.key = key
+        self.input_eos_used = input_eos_used
         self.pad_token = pad_token
 
     def mask_silent_steps(self, input_variable, input_lengths, decoder_outputs):
@@ -129,8 +146,8 @@ class LookupTablePonderer(PonderGenerator):
     _NAME = "lookup_table"
     _KEY = "attention_target"
 
-    def __init__(self):
-        super(LookupTablePonderer, self).__init__(name=self._NAME, key=self._KEY, pad_token=-1)
+    def __init__(self, input_eos_used):
+        super(LookupTablePonderer, self).__init__(name=self._NAME, key=self._KEY, input_eos_used=input_eos_used, pad_token=-1)
 
     def mask_silent_outputs(self, input_variable, input_lengths, decoder_outputs):
         """ Find the last steps for every output sequence sequence.
@@ -150,9 +167,16 @@ class LookupTablePonderer(PonderGenerator):
         # for seq i in the batch, target is decoder_outputs[input_lengths[i]-1][i]
         last_step = torch.zeros_like(decoder_outputs[0])
         eos_step = torch.zeros_like(decoder_outputs[0])
+
+        # If the EOS symbol is used in the input sequence, all input_lengths are too long.
+        if self.input_eos_used:
+            input_eos_substraction = 1
+        else:
+            input_eos_substraction = 0
+
         for i, l in enumerate(input_lengths):
-            last_step[i] = decoder_outputs[l-1][i,:]
-            eos_step[i] = decoder_outputs[l][i, :]
+            last_step[i] = decoder_outputs[l - 1 - input_eos_substraction][i,:]
+            eos_step[i]  = decoder_outputs[l - input_eos_substraction][i, :]
 
         decoder_outputs_non_silent = [first_step, last_step, eos_step]
 
@@ -172,9 +196,15 @@ class LookupTablePonderer(PonderGenerator):
         # take first and second decoder output
         targets_non_silent = decoder_targets[:,0:4].clone()
 
+        # If the EOS symbol is used in the input sequence, all input_lengths are too long.
+        if self.input_eos_used:
+            input_eos_substraction = 1
+        else:
+            input_eos_substraction = 0
+
         # for seq i in the batch, final target is decoder_target[i][input_lengths[i]]
         for i, l in enumerate(input_lengths):
-            targets_non_silent[i,2] = decoder_targets[i][l]
-            targets_non_silent[i, 3] = decoder_targets[i][l+1]
+            targets_non_silent[i, 2] = decoder_targets[i][l - input_eos_substraction]
+            targets_non_silent[i, 3] = decoder_targets[i][l + 1 - input_eos_substraction]
 
         return targets_non_silent


### PR DESCRIPTION
By default, the EOS symbol will be appended to input sequences. It can be turned off with flag `--remove_input_eos`.
Right now, the attention guidance will make the decoder step of the output EOS attend to the input EOS time step.