### PR TITLE
Fix attention methods

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -42,7 +42,7 @@ parser.add_argument('--dropout_p_decoder', type=float, help='Dropout probability
 parser.add_argument('--teacher_forcing_ratio', type=float, help='Teacher forcing ratio', default=0.2)
 parser.add_argument('--pondering', action='store_true')
 parser.add_argument('--attention', choices=['pre-rnn', 'post-rnn'], default=False)
-parser.add_argument('--attention_method', choices=['dot', 'mlp'], default=None)
+parser.add_argument('--attention_method', choices=['dot', 'mlp', 'concat'], default=None)
 parser.add_argument('--use_attention_loss', action='store_true')
 parser.add_argument('--scale_attention_loss', type=float, default=1.)
 parser.add_argument('--batch_size', type=int, help='Batch size', default=32)


### PR DESCRIPTION
Fixes the following:
- Concat attention method not being accepted as argument
- Concat and MLP attention methods not working without manually unrolling the decoder
- Refactoring of the decoder unrolling code