### PR TITLE
Add hard-coded attention method

### DIFF
--- a/lookup_test.sh
+++ b/lookup_test.sh
@@ -2,6 +2,11 @@
 
 TRAIN_PATH=data/lookup-3bit/train.csv
 DEV_PATH=data/lookup-3bit/validation.csv
+TEST1_PATH=data/lookup-3bit/test1_heldout.csv
+TEST2_PATH=data/lookup-3bit/test2_subset.csv
+TEST3_PATH=data/lookup-3bit/test3_hybrid.csv
+TEST4_PATH=data/lookup-3bit/test4_unseen.csv
+TEST5_PATH=data/lookup-3bit/test5_longer.csv
 EXPT_DIR=example
 
 # use small parameters for quicker testing
@@ -31,3 +36,11 @@ python train_model.py \
     --scale_attention_loss 1 \
 	--batch_size $BATCH_SIZE \
 	--optim adam \
+
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TRAIN_PATH
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $DEV_PATH
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TEST1_PATH
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TEST2_PATH
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TEST3_PATH
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TEST4_PATH
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TEST5_PATH

--- a/lookup_test.sh
+++ b/lookup_test.sh
@@ -1,28 +1,33 @@
 #! /bin/sh
 
-TRAIN_PATH=data/lookup/train.csv
-DEV_PATH=data/lookup/unseen.csv
+TRAIN_PATH=data/lookup-3bit/train.csv
+DEV_PATH=data/lookup-3bit/validation.csv
 EXPT_DIR=example
 
 # use small parameters for quicker testing
 EMB_SIZE=300
 H_SIZE=300
-CELL2='lstm'
 CELL='gru'
-EPOCH=500
-CP_EVERY=3000
+EPOCH=100
+PRINT_EVERY=9999999
+SAVE_EVERY=9999999
+ATTN='post-rnn'
+ATTN_METHOD='hard'
+BATCH_SIZE=10
 
-EX=0
-ERR=0
-
-# Start training
-echo "Test training"
-
-
-# test attention loss and pondering
-echo "\n\nTest training with attention loss and ponderer"
-#python train_model.py --train $TRAIN_PATH --dev $DEV_PATH --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'post-rnn' --attention_method 'dot' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0 --use_attention_loss --pondering --batch_size=2 --scale_attention_loss 1 --optim adam
-
-#python train_model.py --train $TRAIN_PATH --dev $DEV_PATH --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'post-rnn' --attention_method 'mlp' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0 --use_attention_loss --pondering  --batch_size=1 --scale_attention_loss 1 --optim adam
-
-python train_model.py --train $TRAIN_PATH --dev $DEV_PATH --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'post-rnn' --attention_method 'mlp' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0 --use_attention_loss  --batch_size=1 --scale_attention_loss 1 --optim adam
+python train_model.py \
+	--train $TRAIN_PATH \
+	--dev $DEV_PATH \
+	--output_dir $EXPT_DIR \
+	--print_every $PRINT_EVERY \
+	--embedding_size $EMB_SIZE \
+	--hidden_size $H_SIZE \
+	--rnn_cell $CELL \
+	--attention $ATTN \
+	--attention_method $ATTN_METHOD \
+	--epoch $EPOCH \
+	--save_every $SAVE_EVERY \
+	--teacher_forcing_ratio 0 \
+    --scale_attention_loss 1 \
+	--batch_size $BATCH_SIZE \
+	--optim adam \

--- a/seq2seq/models/TopKDecoder.py
+++ b/seq2seq/models/TopKDecoder.py
@@ -124,10 +124,10 @@ class TopKDecoder(torch.nn.Module):
         stored_emitted_symbols = list()
         stored_hidden = list()
 
-        for _ in range(0, max_length):
+        for step in range(0, max_length):
 
             # Run the RNN one step forward
-            log_softmax_output, hidden, _ = self.rnn.forward_step(input_var, hidden,
+            log_softmax_output, hidden, _ = self.rnn.forward_step(step, input_var, hidden,
                                                                   inflated_encoder_outputs, function=function)
 
             # If doing local backprop (e.g. supervised training), retain the output layer

--- a/seq2seq/models/attention.py
+++ b/seq2seq/models/attention.py
@@ -76,6 +76,22 @@ class Attention(nn.Module):
         attn.data.masked_fill_(mask, -float('inf'))
 
         attn = F.softmax(attn.view(-1, input_size), dim=1).view(batch_size, -1, input_size)
+        
+        # In the case of hard-coded attentive guidance with variable length examples in a single batch,
+        # The attention will be on the last encoder state. However, the mask will set this to -inf, which will
+        # make all attention scores -inf. Taking the softmax of this results in NaNs. With the following, we set
+        # all NaNs to zero.
+        # Example:
+        # 001 T1 T2  -> 001 101 111 EOS
+        # 101 T1 PAD -> 101 110 PAD EOS
+        # will have attention scores for the last decoder step:
+        # -inf -inf 1
+        # -inf -inf 1
+        # The mask would set this to
+        # -inf -inf 1
+        # -inf -inf -inf
+        # which results in NaNs
+        attn[attn != attn] = 0
 
         # (batch, out_len, in_len) * (batch, in_len, dim) -> (batch, out_len, dim)
         context = torch.bmm(attn, encoder_states)
@@ -232,6 +248,7 @@ class HardCoded(nn.Module):
                 (enc_seqlen-1) * torch.ones(1, dec_seqlen - enc_seqlen, 1)), dim=1)
 
             indices = indices.expand(batch_size, dec_seqlen, 1).long()
+
 
             # Fill the attention guidance with 1's
             attn = attn.scatter_(dim=2, index=indices, value=1)

--- a/seq2seq/models/attention.py
+++ b/seq2seq/models/attention.py
@@ -217,9 +217,12 @@ class HardCoded(nn.Module):
             # In inference mode, we have more decoder steps than encoder steps. These extra steps
             # are ignored when calculating losses and metrics. For the first 'enc_seqlen' decoder steps
             # we generate the diagonal attentive guidance. For all possible steps after that, we just attend to the first encoder state.
-            indices = torch.cat((
-                torch.arange(enc_seqlen).view(1, enc_seqlen, 1),
+            indices = torch.arange(enc_seqlen).view(1, enc_seqlen, 1)
+            if dec_seqlen > enc_seqlen:
+                indices = torch.cat((
+                indices,
                 torch.zeros(1, dec_seqlen - enc_seqlen, 1)), dim=1)
+
             indices = indices.expand(batch_size, dec_seqlen, 1).long()
 
             # Fill the attention guidance with 1's

--- a/seq2seq/models/attention.py
+++ b/seq2seq/models/attention.py
@@ -211,8 +211,8 @@ class HardCoded(nn.Module):
 
         # Add hard-coded attention vector for all decoder steps
         if step == -1:
-            # Initialize all-zero attention vectors
-            attn = torch.zeros(batch_size, dec_seqlen, enc_seqlen)
+            # Initialize attention vectors. These are the pre-softmax scores, so any -inf will become 0 (if there is at least value not -inf)
+            attn = torch.zeros(batch_size, dec_seqlen, enc_seqlen).fill_(-float('inf'))
 
             # In inference mode, we have more decoder steps than encoder steps. These extra steps
             # are ignored when calculating losses and metrics. For the first 'enc_seqlen' decoder steps
@@ -231,8 +231,8 @@ class HardCoded(nn.Module):
             # one step at a time.
             assert dec_seqlen == 1, "Decoder must be unrolled if 'step' is passed"
 
-            # Initialize all-zero attention vectors
-            attn = torch.zeros(batch_size, 1, enc_seqlen)
+            # Initialize attention vectors. These are the pre-softmax scores, so any -inf will become 0 (if there is at least value not -inf)
+            attn = torch.zeros(batch_size, 1, enc_seqlen).fill_(-float('inf'))
 
             # In inference mode, we will have to calculate attention vectors for decoding steps
             # longer than the input length. This will not be included in the calculation of metric and losses

--- a/seq2seq/models/attention.py
+++ b/seq2seq/models/attention.py
@@ -91,7 +91,9 @@ class Attention(nn.Module):
         # -inf -inf 1
         # -inf -inf -inf
         # which results in NaNs
-        attn[attn != attn] = 0
+        attn_containing_nan = attn
+        attn = attn_containing_nan.clone()
+        attn.masked_fill_(attn_containing_nan != attn_containing_nan, 0)
 
         # (batch, out_len, in_len) * (batch, in_len, dim) -> (batch, out_len, dim)
         context = torch.bmm(attn, encoder_states)

--- a/test/test_topkdecoder.py
+++ b/test/test_topkdecoder.py
@@ -91,7 +91,7 @@ class TestDecoderRNN(unittest.TestCase):
                             batch_finished_seqs[b].append(time_batch_queue[t][b][k])
                             continue
                         inputs = torch.autograd.Variable(torch.LongTensor([[inputs]]))
-                        decoder_outputs, hidden, _ = decoder.forward_step(inputs, hidden, None, F.log_softmax)
+                        decoder_outputs, hidden, _ = decoder.forward_step(t, inputs, hidden, None, F.log_softmax)
                         topk_score, topk = decoder_outputs[0].data.topk(beam_size)
                         for score, sym in zip(topk_score.tolist()[0], topk.tolist()[0]):
                             new_queue.append((t, sym, hidden, score + seq_score, k))

--- a/train_model.py
+++ b/train_model.py
@@ -68,6 +68,9 @@ if opt.resume and not opt.load_checkpoint:
 if opt.use_attention_loss and not opt.attention:
     parser.error('Specify attention type to use attention loss')
 
+if opt.use_attention_loss and opt.attention_method == 'hard':
+    parser.error("Attention loss cannot be used in combination with hard-coded attentive guidance")
+
 LOG_FORMAT = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
 logging.basicConfig(format=LOG_FORMAT, level=getattr(logging, opt.log_level.upper()))
 logging.info(opt)

--- a/train_model.py
+++ b/train_model.py
@@ -42,7 +42,7 @@ parser.add_argument('--dropout_p_decoder', type=float, help='Dropout probability
 parser.add_argument('--teacher_forcing_ratio', type=float, help='Teacher forcing ratio', default=0.2)
 parser.add_argument('--pondering', action='store_true')
 parser.add_argument('--attention', choices=['pre-rnn', 'post-rnn'], default=False)
-parser.add_argument('--attention_method', choices=['dot', 'mlp', 'concat'], default=None)
+parser.add_argument('--attention_method', choices=['dot', 'mlp', 'concat', 'hard'], default=None)
 parser.add_argument('--use_attention_loss', action='store_true')
 parser.add_argument('--scale_attention_loss', type=float, default=1.)
 parser.add_argument('--batch_size', type=int, help='Batch size', default=32)


### PR DESCRIPTION
Adds another method for the attention module. Instead of actually calculating attention scores based on the decoder state, it returns a diagonal ground-truth attentive guidance vector. Of course, gradients are now disabled for the attention mechanism and it is non-learnable
Since this attention method must be aware of the decoder step(s) it has to generate attention vectors for, we know pass `step` as an argument to the `forward` function of the Attention module.