### PR TITLE
Store eos settings in checkpoint

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -67,6 +67,12 @@ seq2seq = checkpoint.model
 input_vocab = checkpoint.input_vocab
 output_vocab = checkpoint.output_vocab
 
+if checkpoint.input_eos_used != opt.use_input_eos:
+    parser.error("Input EOS detected in checkpoint, but use_input_eos not set to True. Or vice versa")
+
+if checkpoint.output_eos_used != output_eos_used:
+    parser.error("Output EOS detected in checkpoint, but ignore_output_eos set to True. Or vice versa")
+
 ############################################################################
 # Prepare dataset and loss
 src = SourceField(opt.use_input_eos)

--- a/evaluate.py
+++ b/evaluate.py
@@ -67,11 +67,12 @@ seq2seq = checkpoint.model
 input_vocab = checkpoint.input_vocab
 output_vocab = checkpoint.output_vocab
 
+d = {False: ' not', True: ''}
 if checkpoint.input_eos_used != opt.use_input_eos:
-    parser.error("Input EOS detected in checkpoint, but use_input_eos not set to True. Or vice versa")
+    parser.error("Input EOS%s detected in checkpoint, but use_input_eos set to %r" % (d[opt.input_eos_used], opt.use_input_eos))
 
 if checkpoint.output_eos_used != output_eos_used:
-    parser.error("Output EOS detected in checkpoint, but ignore_output_eos set to True. Or vice versa")
+    parser.error("Output EOS%s detected in checkpoint, but ignore_output_eos set to %r" % (d[opt.output_eos_used], opt.ignore_output_eos))
 
 ############################################################################
 # Prepare dataset and loss

--- a/seq2seq/dataset/fields.py
+++ b/seq2seq/dataset/fields.py
@@ -21,6 +21,8 @@ class SourceField(torchtext.data.Field):
         """
         logger = logging.getLogger(__name__)
 
+        self.eos_used = use_input_eos
+
         if kwargs.get('batch_first') is False:
             logger.warning("Option batch_first has to be set to use pytorch-seq2seq.  Changed to True.")
         kwargs['batch_first'] = True
@@ -55,7 +57,7 @@ class TargetField(torchtext.data.Field):
 
     def __init__(self, include_eos=True, **kwargs):
         logger = logging.getLogger(__name__)
-        self.include_eos = include_eos
+        self.eos_used = include_eos
 
         if kwargs.get('batch_first') == False:
             logger.warning("Option batch_first has to be set to use pytorch-seq2seq.  Changed to True.")
@@ -66,7 +68,7 @@ class TargetField(torchtext.data.Field):
         else:
             func = kwargs['preprocessing']
 
-        if self.include_eos:
+        if self.eos_used:
             app_eos = [self.SYM_EOS]
         else:
             app_eos = []

--- a/seq2seq/trainer/supervised_trainer.py
+++ b/seq2seq/trainer/supervised_trainer.py
@@ -119,7 +119,9 @@ class SupervisedTrainer(object):
                    optimizer=self.optimizer,
                    epoch=start_epoch, step=start_step,
                    input_vocab=data.fields[seq2seq.src_field_name].vocab,
-                   output_vocab=data.fields[seq2seq.tgt_field_name].vocab).save(self.expt_dir, name=model_name)
+                   output_vocab=data.fields[seq2seq.tgt_field_name].vocab,
+                   input_eos_used=data.fields[seq2seq.src_field_name].eos_used,
+                   output_eos_used=data.fields[seq2seq.tgt_field_name].eos_used).save(self.expt_dir, name=model_name)
 
 
         for epoch in range(start_epoch, n_epochs + 1):
@@ -196,7 +198,9 @@ class SupervisedTrainer(object):
                                        optimizer=self.optimizer,
                                        epoch=epoch, step=step,
                                        input_vocab=data.fields[seq2seq.src_field_name].vocab,
-                                       output_vocab=data.fields[seq2seq.tgt_field_name].vocab).save(self.expt_dir, name=model_name)
+                                       output_vocab=data.fields[seq2seq.tgt_field_name].vocab,
+                                       input_eos_used=data.fields[seq2seq.src_field_name].eos_used,
+                                       output_eos_used=data.fields[seq2seq.tgt_field_name].eos_used).save(self.expt_dir, name=model_name)
 
             if step_elapsed == 0: continue
 

--- a/train_model.py
+++ b/train_model.py
@@ -159,6 +159,13 @@ if opt.load_checkpoint is not None:
     tgt.eos_id = tgt.vocab.stoi[tgt.SYM_EOS]
     tgt.sos_id = tgt.vocab.stoi[tgt.SYM_SOS]
 
+    if checkpoint.input_eos_used != opt.use_input_eos:
+        parser.error("Input EOS detected in checkpoint, but use_input_eos not set to True. Or vice versa")
+
+    if checkpoint.output_eos_used != use_output_eos:
+        parser.error("Output EOS detected in checkpoint, but ignore_output_eos set to True. Or vice versa")
+
+
 else:
     # build vocabulary
     src.build_vocab(train, max_size=opt.src_vocab)


### PR DESCRIPTION
Stores the settings for `use_input_eos` and `use_output_eos` in the checkpoints, 
and makes sure that you cannot accidentally use different settings for the trained and evaluated model.