### PR TITLE
Fix metrics index error when using ponderer

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -47,17 +47,17 @@ echo "\n\nTest training without dev set"
 python train_model.py --train $TRAIN_PATH --output_dir $EXPT_DIR --print_every 10 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --epoch $EPOCH --save_every $CP_EVERY
 ERR=$((ERR+$?)); EX=$((EX+1))
 
-# echo "\n\nTest ponderer"
-# python train_model.py --train $LOOKUP --dev $LOOKUP --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --pondering --epoch $EPOCH --save_every $CP_EVERY --batch_size 6 --ignore_output_eos
-# ERR=$((ERR+$?)); EX=$((EX+1))
-# 
-# echo "\n\nTest evaluate from ponderer without ponderer"
-# python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $LOOKUP --batch_size 15 --ignore_output_eos
-# ERR=$((ERR+$?)); EX=$((EX+1))
-# 
-# echo "\n\nTest evaluate from ponderer with ponderer"
-# python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $LOOKUP --batch_size 15 --pondering --ignore_output_eos
-# ERR=$((ERR+$?)); EX=$((EX+1))
+echo "\n\nTest ponderer"
+python train_model.py --train $LOOKUP --dev $LOOKUP --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --pondering --epoch $EPOCH --save_every $CP_EVERY --batch_size 6 --ignore_output_eos
+ERR=$((ERR+$?)); EX=$((EX+1))
+
+echo "\n\nTest evaluate from ponderer without ponderer"
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $LOOKUP --batch_size 15 --ignore_output_eos
+ERR=$((ERR+$?)); EX=$((EX+1))
+
+echo "\n\nTest evaluate from ponderer with ponderer"
+python evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $LOOKUP --batch_size 15 --pondering --ignore_output_eos
+ERR=$((ERR+$?)); EX=$((EX+1))
 
 # test with attention
 echo "\n\nTest training with pre_rnn attention and LSTM cell"

--- a/seq2seq/evaluator/evaluator.py
+++ b/seq2seq/evaluator/evaluator.py
@@ -128,6 +128,4 @@ class Evaluator(object):
 
                 losses = self.update_loss(losses, decoder_outputs, decoder_hidden, other, target_variable)
 
-                metrics = self.update_batch_metrics(metrics, other, target_variable)
-
         return losses, metrics


### PR DESCRIPTION
Makes sure that the metrics calculations are performed before the ponderer is executed.
Note that when pondering is enabled, the losses are calculated on only the copy, target and EOS steps, but that the metrics such as WordAccuracy and SequenceAccuracy are still calculated over the entire sequence