### PR TITLE
fix call to torch.device()

### DIFF
--- a/seq2seq/evaluator/evaluator.py
+++ b/seq2seq/evaluator/evaluator.py
@@ -107,7 +107,7 @@ class Evaluator(object):
             metric.reset()
 
         # create batch iterator
-        iterator_device = torch.cuda.current_device() if torch.cuda.is_available() else -1
+        iterator_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         batch_iterator = torchtext.data.BucketIterator(
             dataset=data, batch_size=self.batch_size,
             sort=True, sort_key=lambda x: len(x.src),

--- a/seq2seq/trainer/supervised_trainer.py
+++ b/seq2seq/trainer/supervised_trainer.py
@@ -85,7 +85,7 @@ class SupervisedTrainer(object):
         epoch_loss_avg = defaultdict(float)
         print_loss_avg = defaultdict(float)
 
-        iterator_device = torch.cuda.current_device() if torch.cuda.is_available() else -1
+        iterator_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         batch_iterator = torchtext.data.BucketIterator(
             dataset=data, batch_size=self.batch_size,
             sort=False, sort_within_batch=True,


### PR DESCRIPTION
The syntax used for setting the device seems to be deprecated in pytorch 0.4, this fix gets rid of the warning messages.
Not sure it really is related to the version of torchtext, but I actually am using 0.3 (current according to the documentation), whereas pip still has 0.2.3 as the current version.