### PR TITLE
BUG: Torch v.0.4.0 deprecation warning fix for NLLLoss size_average

### DIFF
--- a/machine/loss/loss.py
+++ b/machine/loss/loss.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 import torch
 import numpy as np
 
+
 class Loss(object):
     """ Base class for encapsulation of the loss functions.
 
@@ -39,7 +40,8 @@ class Loss(object):
         self.target = target
         self.criterion = criterion
         if not issubclass(type(self.criterion), nn.modules.loss._Loss):
-            raise ValueError("Criterion has to be a subclass of torch.nn._Loss")
+            raise ValueError(
+                "Criterion has to be a subclass of torch.nn._Loss")
         # accumulated loss
         self.acc_loss = 0
         # normalization term
@@ -117,7 +119,8 @@ class Loss(object):
     def scale_loss(self, factor):
         """ Scale loss with a factor
         """
-        self.acc_loss*=factor
+        self.acc_loss *= factor
+
 
 class NLLLoss(Loss):
     """ Batch averaged negative log-likelihood loss.
@@ -138,7 +141,7 @@ class NLLLoss(Loss):
 
         super(NLLLoss, self).__init__(
             self._NAME, self._SHORTNAME, self._INPUTS, self._TARGETS,
-            nn.NLLLoss(ignore_index=ignore_index, size_average=size_average))
+            nn.NLLLoss(ignore_index=ignore_index, reduction='elementwise_mean' if size_average else 'none'))
 
     def get_loss(self):
         if isinstance(self.acc_loss, int):
@@ -156,6 +159,7 @@ class NLLLoss(Loss):
         self.acc_loss += self.criterion(outputs, target)
         self.norm_term += 1
 
+
 class Perplexity(NLLLoss):
     """ Language model perplexity loss.
 
@@ -172,7 +176,8 @@ class Perplexity(NLLLoss):
     _INPUTS = "decoder_output"
 
     def __init__(self, ignore_index=-100):
-        super(Perplexity, self).__init__(ignore_index=ignore_index, size_average=False)
+        super(Perplexity, self).__init__(
+            ignore_index=ignore_index, size_average=False)
 
     def eval_step(self, outputs, target):
         self.acc_loss += self.criterion(outputs, target)

--- a/machine/loss/loss.py
+++ b/machine/loss/loss.py
@@ -141,7 +141,7 @@ class NLLLoss(Loss):
 
         super(NLLLoss, self).__init__(
             self._NAME, self._SHORTNAME, self._INPUTS, self._TARGETS,
-            nn.NLLLoss(ignore_index=ignore_index, reduction='elementwise_mean' if size_average else 'none'))
+            nn.NLLLoss(ignore_index=ignore_index, reduction='elementwise_mean' if size_average else 'sum'))
 
     def get_loss(self):
         if isinstance(self.acc_loss, int):


### PR DESCRIPTION
BUG: Torch v.4.0 deprecation fix for NLLLoss size_average. 

In torch 0.4.0 `size_average` and `reduce` have been replaced by `reduction`. 
This bug fix is backwards compatible for machine, but maybe the better way would be to rename our `size_average` attribute entirely to be in line with Torch?