### PR TITLE
ENH: Add Luong's general attention

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -65,6 +65,15 @@ echo "\n\nTest training with full focus"
 python3 train_model.py --train $LOOKUP --dev $LOOKUP --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'pre-rnn' --attention_method 'mlp' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0.5 --batch_size=7 --full_focus --ignore_output_eos
 ERR=$((ERR+$?)); EX=$((EX+1))
 
+# test general attention
+echo "\n\nTest general attention"
+python3 train_model.py --train $LOOKUP --dev $LOOKUP --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'pre-rnn' --attention_method 'general' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0.5 --batch_size=7 --full_focus --ignore_output_eos
+ERR=$((ERR+$?)); EX=$((EX+1))
+
+python3 train_model.py --train $LOOKUP --dev $LOOKUP --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'post-rnn' --attention_method 'general' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0.5 --batch_size=7 --full_focus --ignore_output_eos
+ERR=$((ERR+$?)); EX=$((EX+1))
+
+
 # test bidirectional
 echo "\n\nTest bidirectional model"
 python3 train_model.py --train $TRAIN_PATH --dev $DEV_PATH --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --bidirectional --epoch $EPOCH --save_every $CP_EVERY --ignore_output_eos

--- a/machine/models/attention.py
+++ b/machine/models/attention.py
@@ -91,8 +91,11 @@ class Attention(nn.Module):
             method = MLP(dim)
         elif method == 'concat':
             method = Concat(dim)
+        elif method == 'general':
+            method = General(dim)
         elif method == 'dot':
             method = Dot()
+
         else:
             raise ValueError("Unknown attention method")
 
@@ -192,5 +195,32 @@ class MLP(nn.Module):
         mlp_output = self.activation(mlp_output)
         out = self.out(mlp_output)
         attn = out.view(batch_size, dec_seqlen, enc_seqlen)
+
+        return attn
+
+
+class General(nn.Module):
+    """
+     Taken from the OpenNMT implementation of Luong's general Attention:
+       general: :math:`\text{score}(H_j, q) = H_j^T W_a q`
+    """
+
+    def __init__(self, dim):
+        super(General, self).__init__()
+        self.linear_in = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, decoder_states, encoder_states):
+
+        # decoder_states (FloatTensor): sequence of queries ``(batch, tgt_len, dim)``
+        # encoder_states (FloatTensor): sequence of sources ``(batch, src_len, dim``
+
+        src_batch, src_len, src_dim = encoder_states.size()
+        tgt_batch, tgt_len, tgt_dim = decoder_states.size()
+
+        decoder_states = decoder_states.view(tgt_batch * tgt_len, tgt_dim)
+        decoder_states = self.linear_in(decoder_states)
+        decoder_states = decoder_states.view(tgt_batch, tgt_len, tgt_dim)
+        encoder_states = encoder_states.transpose(1, 2)
+        attn = torch.bmm(decoder_states, encoder_states)
 
         return attn

--- a/machine/models/attention.py
+++ b/machine/models/attention.py
@@ -213,8 +213,6 @@ class General(nn.Module):
 
         # decoder_states (FloatTensor): sequence of queries ``(batch, tgt_len, dim)``
         # encoder_states (FloatTensor): sequence of sources ``(batch, src_len, dim``
-
-        src_batch, src_len, src_dim = encoder_states.size()
         tgt_batch, tgt_len, tgt_dim = decoder_states.size()
 
         decoder_states = decoder_states.view(tgt_batch * tgt_len, tgt_dim)

--- a/train_model.py
+++ b/train_model.py
@@ -108,7 +108,7 @@ def init_argparser():
     parser.add_argument(
         '--attention', choices=['pre-rnn', 'post-rnn'], default=False)
     parser.add_argument('--attention_method',
-                        choices=['dot', 'mlp', 'concat'], default=None)
+                        choices=['dot', 'mlp', 'concat', 'general'], default=None)
     parser.add_argument('--metrics', nargs='+', default=['seq_acc'], choices=[
                         'word_acc', 'seq_acc', 'target_acc', 'sym_rwr_acc', 'bleu'], help='Metrics to use')
     parser.add_argument('--full_focus', action='store_true')


### PR DESCRIPTION
Adds the general attention method from Effective Approaches to Attention-based Neural Machine Translation (Luong et al., 2015). This is adapted from the openNMT library and is the default attention method there. It is less efficient than dot but more efficient than our current MLP and Concat attention methods and might help replication to have in machine. 

In general attention the alignment scores are calculated as:
 `\text{score}(H_j, q) = H_j^T W_a q`

Where `H_j` are the encoder states (source matrix), and `q` are the decoder states (queries). `W_a` is a learn-able parameter (Linear layer without bias).