### PR TITLE
ENH: Add ReduceLR and EarlyStopping Callbacks

### DIFF
--- a/machine/util/callbacks/__init__.py
+++ b/machine/util/callbacks/__init__.py
@@ -3,3 +3,5 @@ from .callback_container import CallbackContainer
 from .history import History
 from .logger import Logger
 from .model_checkpoint import ModelCheckpoint
+from .early_stopping_callback import EarlyStoppingCallback
+from .reduce_lr_callback import ReduceLRonPlateauCallback

--- a/machine/util/callbacks/early_stopping_callback.py
+++ b/machine/util/callbacks/early_stopping_callback.py
@@ -1,0 +1,94 @@
+from machine.util.callbacks import Callback
+
+
+class EarlyStoppingCallback(Callback):
+    """
+    Original callback taken from https://github.com/ncullen93/torchsample
+    Early Stopping to terminate training early under certain conditions
+    """
+
+    def __init__(self,
+                 monitor='eval_losses',
+                 lm_name=None,
+                 min_delta=0,
+                 patience=5,
+                 minimize=True):
+        """
+        EarlyStopping callback to exit the training loop if training or
+        validation loss or metric does not improve by a certain amount
+        for a certain number of epochs
+        Args:
+            monitor : string in {'eval_losses', 'eval_metrics', 'train_losses', 'train_metrics'}
+                whether to monitor train or val loss
+            lm_name: loss or metric name eg. 'Avg NLLoss' or 'Word Accuracy'
+                    If not specified then the first element
+                    in the monitor array is used
+                    (default None)
+            min_delta : float
+                minimum change in monitored value to qualify as improvement.
+                This number should be positive.
+            patience : integer
+                number of epochs to wait for improvment before terminating.
+                the counter be reset after each improvment
+            minimize: minimize quantity, if false then early stopping will maximize
+        """
+        if 'loss' in monitor:
+            self.loss = True
+        elif 'metric' in monitor:
+            self.loss = False
+        else:
+            raise ValueError(
+                "Monitor must be string in {'eval_losses', \
+                'eval_metrics', 'train_losses', 'train_metrics'}")
+
+        self.monitor = monitor
+        self.lm_name = lm_name
+        self.minimize = minimize
+
+        self.min_delta = min_delta
+        self.patience = patience
+        self.wait = 0
+        self.best_lm = 1e-15
+        super(EarlyStoppingCallback, self).__init__()
+
+    def on_train_begin(self, info=None):
+        self.wait = 0
+        if self.minimize:
+            self.best_lm = 1e15
+        else:
+            self.best_lm = -1e15
+
+    def on_epoch_end(self, info=None):
+        """
+        Function called at the end of every epoch
+        This allows specifing what eval or train loss to use
+        """
+
+        # If specific loss/metric name is specified
+        if self.lm_name is not None:
+            for lm in info[self.monitor]:
+                if lm.name == self.lm_name:
+                    current_loss = self.get_loss_metric(lm)
+                    break
+        else:  # just use the first metric/loss in the array
+            current_loss = self.get_loss_metric(info[self.monitor][0])
+
+        # Compare current loss to previous best
+        if self.minimize:
+            update_best = (current_loss - self.best_lm) < -self.min_delta
+        else:
+            update_best = (self.best_lm - current_loss) < -self.min_delta
+
+        if update_best:
+            self.best_lm = current_loss
+            self.wait = 1
+        else:
+            if self.wait >= self.patience:
+                self.trainer._stop_training = True
+            self.wait += 1
+
+    def get_loss_metric(self, lm):
+        if self.loss:
+            return lm.get_loss()
+        else:
+            return lm.get_val()

--- a/machine/util/callbacks/logger.py
+++ b/machine/util/callbacks/logger.py
@@ -49,8 +49,6 @@ class Logger(Callback):
         loss_total, log_, _ = self.get_losses(
             info['eval_losses'], info['eval_metrics'], info['step'])
 
-        # Update learning rate - Needs checking
-        self.trainer.optimizer.update(loss_total, info['epoch'])
         log_msg += ", Dev set: " + log_
 
         self.logger.info(log_msg)
@@ -105,5 +103,6 @@ class Logger(Callback):
     def on_train_end(self, info=None):
         # Log if training was ended early with flag _stop_training
         if self.trainer._stop_training:
-            log_msg = 'Terminated Training Early at Epoch {}'.format(info['epoch'])
+            log_msg = 'Terminated Training Early at Epoch {}'.format(
+                info['epoch'])
             self.logger.info(log_msg)

--- a/machine/util/callbacks/reduce_lr_callback.py
+++ b/machine/util/callbacks/reduce_lr_callback.py
@@ -1,0 +1,80 @@
+from machine.util.callbacks import Callback
+import torch
+
+
+class ReduceLRonPlateauCallback(Callback):
+    """
+    Callback wrapper for Reduce LR on Plateau
+    """
+
+    def __init__(self,
+                 monitor='eval_losses',
+                 mode='min', factor=0.1,
+                 patience=10, verbose=False,
+                 threshold=0.0001, threshold_mode='rel',
+                 cooldown=0, min_lr=0, eps=1e-08):
+        """
+
+        Args:
+            monitor (str): Picked from {'eval_losses', 'train_losses'}
+            mode (str): One of min, max. In min mode, lr will be reduced when the
+                        quantity monitored has stopped decreasing; in max mode
+                        it will be reduced when the quantity
+                        monitored has stopped increasing. Default: ‘min’.
+            factor (float): Factor by which the learning rate will be reduced.
+                            new_lr = lr * factor. Default: 0.1.
+            patience (int): Number of epochs with no improvement after which
+                            learning rate will be reduced. For example,
+                            if patience = 2, then we will ignore the first 2 epochs
+                            with no improvement, and will only decrease the LR
+                            after the 3rd epoch if the loss still hasn’t improved
+                            then. Default: 10.
+            verbose (bool): If True, prints a message to stdout for each update.
+                            Default: False.
+            threshold (float): Threshold for measuring the new optimum,
+                                to only focus on significant changes.
+                                Default: 1e-4.
+            threshold_mode (str): One of rel, abs. In rel mode,
+                                dynamic_threshold = best * ( 1 + threshold ) in ‘max’ mode
+                                or best * ( 1 - threshold ) in min mode.
+                                In abs mode, dynamic_threshold = best + threshold in max mode
+                                or best - threshold in min mode.
+                                Default: ‘rel’.
+            cooldown (int): Number of epochs to wait before resuming normal
+                            operation after lr has been reduced.
+                            Default: 0.
+            min_lr (float or list): A scalar or a list of scalars.
+                                    A lower bound on the learning rate of
+                                    all param groups or each group respectively.
+                                    Default: 0.
+            eps (float): Minimal decay applied to lr. If the difference between
+                        new and old lr is smaller than eps,
+                        the update is ignored. Default: 1e-8.
+        """
+        self.monitor = monitor
+        self.mode = mode
+        self.factor = factor
+        self.patience = patience
+        self.verbose = verbose
+        self.threshold = threshold
+        self.threshold_mode = threshold_mode
+        self.min_lr = min_lr
+        self.eps = eps
+        super(ReduceLRonPlateauCallback, self).__init__()
+
+    def on_train_begin(self, info=None):
+        # initialize scheduler
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+            self.trainer.optimizer.optimizer, mode=self.mode,
+            factor=self.factor, patience=self.patience, verbose=self.verbose,
+            threshold=self.threshold, threshold_mode=self.threshold_mode,
+            min_lr=self.min_lr, eps=self.eps)
+
+        self.trainer.optimizer.set_scheduler(scheduler)
+
+    def on_epoch_end(self, info=None):
+        loss_total, _, _ = self.get_losses(
+            info[self.monitor], info[self.monitor], info['step'])
+
+        # Updates learning rate using scheduler
+        self.trainer.optimizer.update(loss_total, info['epoch'])

--- a/test/test_early_stopping_callback.py
+++ b/test/test_early_stopping_callback.py
@@ -1,0 +1,76 @@
+import unittest
+import mock
+
+
+from machine.util.callbacks import EarlyStoppingCallback
+
+
+class TestEarlyStoppingCallback(unittest.TestCase):
+    def setUp(self):
+        self.temp_callback = EarlyStoppingCallback()
+        self.temp_callback._get_loss_metric = mock.MagicMock(return_value=3)
+
+    def test_train_begin(self):
+        self.temp_callback.on_train_begin()
+
+    def test_get_current(self):
+        mock_metric = mock.MagicMock()
+        mock_metric.name = 'tmp'
+        tmp_info = {self.temp_callback.monitor: [mock_metric]}
+
+        # test with no objective name
+        self.assertEqual(3, self.temp_callback._get_current(tmp_info))
+        # test with present objective name
+        self.temp_callback.objective_name = 'tmp'
+        self.assertEqual(3, self.temp_callback._get_current(tmp_info))
+        # test for missing objective name in monitor
+        tmp_info = {self.temp_callback.monitor: []}
+        self.assertRaises(
+            ValueError, lambda: self.temp_callback._get_current(tmp_info))
+
+    def test_on_epoch_end(self):
+        self.temp_callback.wait = 0
+        # Update if minimize if True
+        self.temp_callback._get_current = mock.MagicMock(return_value=3)
+        self.temp_callback.best = 4
+        self.temp_callback.on_epoch_end()
+        self.assertEqual(3, self.temp_callback.best)
+
+        # Don't Update if minimize and current higher
+        self.temp_callback.best = 2
+        self.temp_callback.on_epoch_end()
+        self.assertEqual(2, self.temp_callback.best)
+
+        # Don't Update if delta
+        self.temp_callback.min_delta = 2
+        self.temp_callback.best = 4
+        self.temp_callback.on_epoch_end()
+        self.assertEqual(4, self.temp_callback.best)
+
+        # Update if maximizing
+        self.temp_callback.min_delta = 0
+        self.temp_callback.minimize = -1
+        self.temp_callback.best = 2
+        self.temp_callback.on_epoch_end()
+        self.assertEqual(3, self.temp_callback.best)
+
+        # Don't Update if maximizing and current lower
+        self.temp_callback.best = 4
+        self.temp_callback.on_epoch_end()
+        self.assertEqual(4, self.temp_callback.best)
+
+        # Don't update if delta
+        self.temp_callback.min_delta = 2
+        self.temp_callback.best = 2
+        self.temp_callback.on_epoch_end()
+        self.assertEqual(2, self.temp_callback.best)
+
+    def test_bad_monitor_value(self):
+        self.assertRaises(
+            ValueError, lambda: EarlyStoppingCallback(monitor='eval'))
+        self.assertRaises(
+            ValueError, lambda: EarlyStoppingCallback(monitor='val_losses'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds two custom callbacks to machine:

- `EarlyStoppingCallback` : callback that can stop training early by monitoring a designed target metric or loss over time. It uses a default patience of 10 epochs to decide whether to stop training early. One can pass in a string in `{'eval_losses', 'eval_metrics', 'train_losses', 'train_metrics'}` as the monitor (default eval_losses) to decide what to stop training on. To precise what precise metric or loss (if there are multiple) the name of it must be passed to `lm_name`, if no name is passed the first element in the monitor array is used. Other parameters include:
	-  `min_delta`: (float) decides the minimum change in monitored value to qualify as improvement, 
	-  `patience`: (int) number of epochs to wait for improvment before terminating. The counter is reset after each improvement.
	-  `minimize`: (bool, default: true) minimize quantity, if false then early stopping will stop when metric/loss cannot be maximized anymore

- `ReduceLRonPlateauCallback` : callback that is a wrapper for `torch.optim.lr_scheduler.ReduceLROnPlateau`. Can be passed same arguments and has same defaults as the torch class.