### PR TITLE
Multiple-GPU Support (with nn.DataParallel)

### DIFF
--- a/example.sh
+++ b/example.sh
@@ -2,7 +2,7 @@
 
 TRAIN_PATH=test/test_data/train.txt
 DEV_PATH=test/test_data/dev.txt
-EXPT_DIR=example
+EXPT_DIR=dir_example
 
 # set values
 EMB_SIZE=16
@@ -17,8 +17,8 @@ TF=0.5
 echo "Train model on example data"
 python3 train_model.py --train $TRAIN_PATH --output_dir $EXPT_DIR --print_every $PRINT_EVERY --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --n_layers $N_LAYERS --epoch $EPOCH --print_every $PRINT_EVERY --teacher_forcing $TF --attention 'pre-rnn' --attention_method 'mlp'
 
-echo "\n\nEvaluate model on test data"
-python3 evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TRAIN_PATH
+# echo "\n\nEvaluate model on test data"
+# python3 evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TRAIN_PATH
 
-echo "\n\nRun in inference mode"
-python3 infer.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) 
+# echo "\n\nRun in inference mode"
+# python3 infer.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) 

--- a/example.sh
+++ b/example.sh
@@ -2,7 +2,7 @@
 
 TRAIN_PATH=test/test_data/train.txt
 DEV_PATH=test/test_data/dev.txt
-EXPT_DIR=dir_example
+EXPT_DIR=example
 
 # set values
 EMB_SIZE=16
@@ -17,8 +17,8 @@ TF=0.5
 echo "Train model on example data"
 python3 train_model.py --train $TRAIN_PATH --output_dir $EXPT_DIR --print_every $PRINT_EVERY --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --n_layers $N_LAYERS --epoch $EPOCH --print_every $PRINT_EVERY --teacher_forcing $TF --attention 'pre-rnn' --attention_method 'mlp'
 
-# echo "\n\nEvaluate model on test data"
-# python3 evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TRAIN_PATH
+echo "\n\nEvaluate model on test data"
+python3 evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $TRAIN_PATH
 
-# echo "\n\nRun in inference mode"
-# python3 infer.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) 
+echo "\n\nRun in inference mode"
+python3 infer.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) 

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -22,14 +22,14 @@ ERR=0
 
 # Start training
 echo "Test training"
-python3 train_model.py --train $TRAIN_PATH --dev $DEV_PATH --monitor $DEV_PATH $TRAIN_PATH --output_dir $EXPT_DIR --print_every 30 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --epoch $EPOCH --save_every $CP_EVERY --batch_size 6 --write-logs 'log_test'
+python3 train_model.py --train $TRAIN_PATH --dev $DEV_PATH --monitor $DEV_PATH $TRAIN_PATH --output_dir $EXPT_DIR --print_every 30 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --epoch $EPOCH --save_every $CP_EVERY --batch_size 12 --write-logs 'log_test'
 ERR=$((ERR+$?)); EX=$((EX+1))
 
 rm $EXPT_DIR/log_test
 
 # Resume training
 echo "\n\nTest resume training"
-python3 train_model.py --train $TRAIN_PATH --dev $DEV_PATH --resume-training --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --epoch $EPOCH --load_checkpoint $(ls -t $EXPT_DIR | head -1) --save_every $CP_EVERY --optim rmsprop --batch_size 6
+python3 train_model.py --train $TRAIN_PATH --dev $DEV_PATH --resume-training --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --epoch $EPOCH --load_checkpoint $(ls -t $EXPT_DIR | head -1) --save_every $CP_EVERY --optim rmsprop --batch_size 12
 ERR=$((ERR+$?)); EX=$((EX+1))
 
 echo "\n\nTest train from checkpoint"
@@ -39,7 +39,7 @@ ERR=$((ERR+$?)); EX=$((EX+1))
 
 # # evaluate.py
 echo "\n\nTest evaluator"
-python3 evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $DEV_PATH --batch_size 15
+python3 evaluate.py --checkpoint_path $EXPT_DIR/$(ls -t $EXPT_DIR/ | head -1) --test_data $DEV_PATH --batch_size 12
 ERR=$((ERR+$?)); EX=$((EX+1))
 
 #test training without dev set
@@ -62,7 +62,7 @@ ERR=$((ERR+$?)); EX=$((EX+1))
 
 # test full focus
 echo "\n\nTest training with full focus"
-python3 train_model.py --train $LOOKUP --dev $LOOKUP --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'pre-rnn' --attention_method 'mlp' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0.5 --batch_size=7 --full_focus --ignore_output_eos
+python3 train_model.py --train $LOOKUP --dev $LOOKUP --output_dir $EXPT_DIR --print_every 50 --embedding_size $EMB_SIZE --hidden_size $H_SIZE --rnn_cell $CELL --attention 'pre-rnn' --attention_method 'mlp' --epoch $EPOCH --save_every $CP_EVERY --teacher_forcing_ratio 0.5 --batch_size 12 --full_focus --ignore_output_eos
 ERR=$((ERR+$?)); EX=$((EX+1))
 
 # test bidirectional

--- a/machine/dataset/get_standard_iter.py
+++ b/machine/dataset/get_standard_iter.py
@@ -1,8 +1,6 @@
 import torch
 import torchtext
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
 
 def get_standard_iter(data, batch_size=64, device=None):
     """

--- a/machine/evaluator/evaluator.py
+++ b/machine/evaluator/evaluator.py
@@ -50,7 +50,7 @@ class Evaluator(object):
 
         Args:
             decoder_outputs (torch.Tensor): decoder outputs of a batch
-            decoder_hidden (torch.Tensor): decoder hidden states for a batch
+            decoder_hidden (torch.Tensor): (batch first) decoder hidden states for a batch
             other (dict): maps extra outputs to torch.Tensors
             target_variable (dict): map of keys to different targets
 
@@ -76,7 +76,7 @@ class Evaluator(object):
         Args:
             losses (list): a list with machine.loss.Loss objects
             decoder_outputs (torch.Tensor): decoder outputs of a batch
-            decoder_hidden (torch.Tensor): decoder hidden states for a batch
+            decoder_hidden (torch.Tensor): (batch first) decoder hidden states for a batch
             other (dict): maps extra outputs to torch.Tensors
             target_variable (dict): map of keys to different targets
 

--- a/machine/evaluator/evaluator.py
+++ b/machine/evaluator/evaluator.py
@@ -132,7 +132,7 @@ class Evaluator(object):
                     batch)
 
                 decoder_outputs, decoder_hidden, other = model(
-                    input_variable, input_lengths.tolist(), target_variable)
+                    input_variable, input_lengths, target_variable)
 
                 # Compute metric(s) over one batch
                 metrics = self.update_batch_metrics(

--- a/machine/evaluator/evaluator.py
+++ b/machine/evaluator/evaluator.py
@@ -7,8 +7,6 @@ import torchtext
 from machine.loss import NLLLoss
 from machine.metrics import WordAccuracy, SequenceAccuracy
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
 
 class Evaluator(object):
     """ Class to evaluate models with given datasets.

--- a/machine/evaluator/predictor.py
+++ b/machine/evaluator/predictor.py
@@ -13,7 +13,7 @@ class Predictor(object):
             tgt_vocab (machine.dataset.vocabulary.Vocabulary): target sequence vocabulary
         """
         if device is None:
-            device = torch.device(
+            self.device = torch.device(
                 "cuda" if torch.cuda.is_available() else "cpu")
         self.model = model.to(device)
 
@@ -32,7 +32,8 @@ class Predictor(object):
             by the pre-trained model
         """
         src_id_seq = torch.tensor([self.src_vocab.stoi[tok]
-                                   for tok in src_seq], dtype=torch.long, device=device).view(1, -1)
+                                   for tok in src_seq], dtype=torch.long,
+                                  device=self.device).view(1, -1)
 
         softmax_list, _, other = self.model(src_id_seq, [len(src_seq)])
         length = other['length'][0]

--- a/machine/evaluator/predictor.py
+++ b/machine/evaluator/predictor.py
@@ -1,11 +1,9 @@
 import torch
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
 
 class Predictor(object):
 
-    def __init__(self, model, src_vocab, tgt_vocab):
+    def __init__(self, model, src_vocab, tgt_vocab, device=None):
         """
         Predictor class to evaluate for a given model.
         Args:
@@ -14,6 +12,9 @@ class Predictor(object):
             src_vocab (machine.dataset.vocabulary.Vocabulary): source sequence vocabulary
             tgt_vocab (machine.dataset.vocabulary.Vocabulary): target sequence vocabulary
         """
+        if device = None:
+            device = torch.device(
+                "cuda" if torch.cuda.is_available() else "cpu")
         self.model = model.to(device)
 
         self.model.eval()

--- a/machine/evaluator/predictor.py
+++ b/machine/evaluator/predictor.py
@@ -12,7 +12,7 @@ class Predictor(object):
             src_vocab (machine.dataset.vocabulary.Vocabulary): source sequence vocabulary
             tgt_vocab (machine.dataset.vocabulary.Vocabulary): target sequence vocabulary
         """
-        if device = None:
+        if device is None:
             device = torch.device(
                 "cuda" if torch.cuda.is_available() else "cpu")
         self.model = model.to(device)

--- a/machine/metrics/metrics.py
+++ b/machine/metrics/metrics.py
@@ -6,8 +6,6 @@ import math
 import numpy as np
 import torch
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
 
 class Metric(object):
     """ Base class for encapsulation of the metrics functions.
@@ -179,10 +177,14 @@ class SequenceAccuracy(Metric):
     _SHORTNAME = "seq_acc"
     _INPUT = "seqlist"
 
-    def __init__(self, ignore_index=None):
+    def __init__(self, ignore_index=None, device=None):
         self.ignore_index = ignore_index
         self.seq_match = 0
         self.seq_total = 0
+
+        if device = None:
+            self.device = torch.device(
+                "cuda" if torch.cuda.is_available() else "cpu")
 
         super(SequenceAccuracy, self).__init__(
             self._NAME, self._SHORTNAME, self._INPUT)
@@ -205,9 +207,9 @@ class SequenceAccuracy(Metric):
 
         # compute sequence accuracy over batch
         match_per_seq = torch.zeros(
-            batch_size, dtype=torch.float, device=device)
+            batch_size, dtype=torch.float, device=self.device)
         total_per_seq = torch.zeros(
-            batch_size, dtype=torch.float, device=device)
+            batch_size, dtype=torch.float, device=self.device)
 
         for step, step_output in enumerate(outputs):
             target = targets[:, step + 1]

--- a/machine/metrics/metrics.py
+++ b/machine/metrics/metrics.py
@@ -182,7 +182,7 @@ class SequenceAccuracy(Metric):
         self.seq_match = 0
         self.seq_total = 0
 
-        if device = None:
+        if device is None:
             self.device = torch.device(
                 "cuda" if torch.cuda.is_available() else "cpu")
 

--- a/machine/models/DecoderRNN.py
+++ b/machine/models/DecoderRNN.py
@@ -246,8 +246,11 @@ class DecoderRNN(BaseRNN):
         ret_dict[DecoderRNN.KEY_LENGTH] = torch.tensor(lengths, device=device)
 
         # Transpose decoder hiddens in order to make parallel GPU work
-        for h in decoder_hidden:
-            h.transpose_(0, 1)
+        if self.rnn_cell is nn.LSTM:
+            for h in decoder_hidden:
+                h.transpose_(0, 1)
+        elif self.rnn_cell is nn.GRU:
+            decoder_hidden.transpose_(0, 1)
 
         return decoder_outputs, decoder_hidden, ret_dict
 

--- a/machine/models/DecoderRNN.py
+++ b/machine/models/DecoderRNN.py
@@ -243,7 +243,7 @@ class DecoderRNN(BaseRNN):
                 decode(di, step_output, step_attn)
 
         ret_dict[DecoderRNN.KEY_SEQUENCE] = sequence_symbols
-        ret_dict[DecoderRNN.KEY_LENGTH] = ltorch.tensor(lengths, device=device)
+        ret_dict[DecoderRNN.KEY_LENGTH] = torch.tensor(lengths, device=device)
 
         # Transpose decoder hiddens in order to make parallel GPU work
         h_n, c_n = decoder_hidden

--- a/machine/models/DecoderRNN.py
+++ b/machine/models/DecoderRNN.py
@@ -246,10 +246,8 @@ class DecoderRNN(BaseRNN):
         ret_dict[DecoderRNN.KEY_LENGTH] = torch.tensor(lengths, device=device)
 
         # Transpose decoder hiddens in order to make parallel GPU work
-        h_n, c_n = decoder_hidden
-        h_n = h_n.transpose(0, 1)
-        c_n = c_n.transpose(0, 1)
-        decoder_hidden = (h_n, c_n)
+        for h in decoder_hidden:
+            h.transpose_(0, 1)
 
         return decoder_outputs, decoder_hidden, ret_dict
 

--- a/machine/models/DecoderRNN.py
+++ b/machine/models/DecoderRNN.py
@@ -243,7 +243,13 @@ class DecoderRNN(BaseRNN):
                 decode(di, step_output, step_attn)
 
         ret_dict[DecoderRNN.KEY_SEQUENCE] = sequence_symbols
-        ret_dict[DecoderRNN.KEY_LENGTH] = lengths.tolist()
+        ret_dict[DecoderRNN.KEY_LENGTH] = ltorch.tensor(lengths, device=device)
+
+        # Transpose decoder hiddens in order to make parallel GPU work
+        h_n, c_n = decoder_hidden
+        h_n = h_n.transpose(0, 1)
+        c_n = c_n.transpose(0, 1)
+        decoder_hidden = (h_n, c_n)
 
         return decoder_outputs, decoder_hidden, ret_dict
 

--- a/machine/models/DecoderRNN.py
+++ b/machine/models/DecoderRNN.py
@@ -203,6 +203,8 @@ class DecoderRNN(BaseRNN):
         else:
             unrolling = False
 
+        self.rnn.flatten_parameters()
+
         if unrolling:
             symbols = None
             for di in range(max_length):

--- a/machine/models/EncoderRNN.py
+++ b/machine/models/EncoderRNN.py
@@ -54,7 +54,7 @@ class EncoderRNN(BaseRNN):
 
         Args:
             input_var (batch, seq_len): tensor containing the features of the input sequence.
-            input_lengths (list of int, optional): A list that contains the lengths of sequences
+            input_lengths (tensor int, optional): A tensor that contains the lengths of sequences
               in the mini-batch
             **hidden** : Tuple of (h_0, c_0), each of shape (num_layers * num_directions, batch, hidden_size)
               where h_0 is tensor containing the initial hidden state, and c_0 is a tensor
@@ -68,6 +68,7 @@ class EncoderRNN(BaseRNN):
         embedded = self.input_dropout(embedded)
 
         if self.variable_lengths:
+            total_length = embedded.size(1)  # get the max sequence length
             embedded = nn.utils.rnn.pack_padded_sequence(
                 embedded, input_lengths, batch_first=True)
 
@@ -78,6 +79,6 @@ class EncoderRNN(BaseRNN):
 
         if self.variable_lengths:
             output, _ = nn.utils.rnn.pad_packed_sequence(
-                output, batch_first=True)
+                output, batch_first=True, total_length=total_length)
 
         return output, hidden

--- a/machine/models/EncoderRNN.py
+++ b/machine/models/EncoderRNN.py
@@ -67,6 +67,8 @@ class EncoderRNN(BaseRNN):
         embedded = self.embedding(input_var)
         embedded = self.input_dropout(embedded)
 
+        self.rnn.flatten_parameters()
+
         if self.variable_lengths:
             total_length = embedded.size(1)  # get the max sequence length
             embedded = nn.utils.rnn.pack_padded_sequence(

--- a/machine/models/attention.py
+++ b/machine/models/attention.py
@@ -2,8 +2,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
 
 class Attention(nn.Module):
     """

--- a/machine/trainer/supervised_trainer.py
+++ b/machine/trainer/supervised_trainer.py
@@ -18,8 +18,6 @@ from machine.util.checkpoint import Checkpoint
 from machine.util.callbacks import CallbackContainer, Logger, ModelCheckpoint, History
 from machine.util.log import Log
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
 
 class SupervisedTrainer(object):
     """ The SupervisedTrainer class helps in setting up a training framework in a

--- a/machine/trainer/supervised_trainer.py
+++ b/machine/trainer/supervised_trainer.py
@@ -123,7 +123,7 @@ class SupervisedTrainer(object):
                     batch)
 
                 self.batch_losses = self._train_batch(input_variables,
-                                                      input_lengths.tolist(),
+                                                      input_lengths,
                                                       target_variables,
                                                       teacher_forcing_ratio)
                 callbacks.on_batch_end(batch)
@@ -131,7 +131,7 @@ class SupervisedTrainer(object):
             callbacks.on_epoch_end(epoch)
 
             # Stop training early if flag _stop_training is True
-            if self._stop_training: 
+            if self._stop_training:
                 break
 
         logs = callbacks.on_train_end()

--- a/machine/util/checkpoint.py
+++ b/machine/util/checkpoint.py
@@ -5,6 +5,7 @@ import shutil
 import logging
 
 import torch
+from torch.nn import DataParallel
 import dill
 
 
@@ -76,7 +77,7 @@ class Checkpoint(object):
                     },
                    os.path.join(path, self.TRAINER_STATE_NAME))
 
-        if isinstance(self.model, torch.nn.DataParallel):
+        if isinstance(self.model, DataParallel):
             torch.save(self.model.module, os.path.join(path, self.MODEL_NAME))
         else:
             torch.save(self.model, os.path.join(path, self.MODEL_NAME))

--- a/machine/util/checkpoint.py
+++ b/machine/util/checkpoint.py
@@ -76,7 +76,7 @@ class Checkpoint(object):
                     },
                    os.path.join(path, self.TRAINER_STATE_NAME))
 
-        if isinstance(model, torch.nn.DataParallel):
+        if isinstance(self.model, torch.nn.DataParallel):
             torch.save(self.model.module, os.path.join(path, self.MODEL_NAME))
         else:
             torch.save(self.model, os.path.join(path, self.MODEL_NAME))

--- a/machine/util/checkpoint.py
+++ b/machine/util/checkpoint.py
@@ -75,7 +75,11 @@ class Checkpoint(object):
                     'optimizer': self.optimizer
                     },
                    os.path.join(path, self.TRAINER_STATE_NAME))
-        torch.save(self.model, os.path.join(path, self.MODEL_NAME))
+
+        if isinstance(model, torch.nn.DataParallel):
+            torch.save(self.model.module, os.path.join(path, self.MODEL_NAME))
+        else:
+            torch.save(self.model, os.path.join(path, self.MODEL_NAME))
 
         with open(os.path.join(path, self.INPUT_VOCAB_FILE), 'wb') as fout:
             dill.dump(self.input_vocab, fout)

--- a/train_model.py
+++ b/train_model.py
@@ -253,6 +253,11 @@ def initialize_model(opt, src, tgt, train):
                          rnn_cell=opt.rnn_cell,
                          eos_id=tgt.eos_id, sos_id=tgt.sos_id)
     seq2seq = Seq2seq(encoder, decoder)
+
+    if torch.cuda.device_count() > 1:
+        logging.info("Using {} GPUs".format(torch.cuda.device_count()))
+        seq2seq = torch.nn.DataParallel(seq2seq)
+
     seq2seq.to(device)
 
     return seq2seq, input_vocab, output_vocab

--- a/train_model.py
+++ b/train_model.py
@@ -254,6 +254,7 @@ def initialize_model(opt, src, tgt, train):
                          eos_id=tgt.eos_id, sos_id=tgt.sos_id)
     seq2seq = Seq2seq(encoder, decoder)
 
+    # This enables using all GPUs available
     if torch.cuda.device_count() > 1:
         logging.info("Using {} GPUs".format(torch.cuda.device_count()))
         seq2seq = torch.nn.DataParallel(seq2seq)


### PR DESCRIPTION
This PR enables using the `nn.DataParallel` class with `machine`. The main change is the `decoder_hidden` are now passed back batch first so that the dimensions are (batch\_size X num\_layers * num\_directions X hidden\_size). This has no impact on any current part of machine since the decoder hidden are never used but might play a role in user implemented custom loss. The other changes necessary to make it work with multiple gpu were:

- Changing the lengths returned in the DecoderRNN dictionary to tensor form
- Changing the saving (checkpointing) to include a check for `nn.DataParallel`.
- Flattening the rnn parameters during the forward calls to keep memory contiguous in both `EncoderRNN` and `DecoderRNN`
- Changing the calls slightly to pack\_padded and pad\_packed in the `EncoderRNN` because of batch sizes now being potentially different on each GPU we need to pad to max input length  [https://pytorch.org/docs/stable/notes/faq.html#pack-rnn-unpack-with-data-parallelism](https://pytorch.org/docs/stable/notes/faq.html#pack-rnn-unpack-with-data-parallelism).

I also went through and cleaned general calls assigning ` device = torch.device("cuda" if torch.cuda.is_available() else "cpu")` unless they were absolutely necessary.

I have run all the integration tests and the `example.sh` file using 4 GPUs without error. The only change I had to do for some tests was expanding the batch size since using multiple GPUs required a larger batch size.  

To show an example of how use `nn.DataParallel`, I have included a snippet in the train_model.py file that automatically uses all GPU available:

```
# This enables using all GPUs available
if torch.cuda.device_count() > 1:
    seq2seq = torch.nn.DataParallel(seq2seq)
```